### PR TITLE
rButtonTemplate: Fix for 8.1.5 ItemButtons not having a checked texture

### DIFF
--- a/wow8.0/rButtonTemplate/core.lua
+++ b/wow8.0/rButtonTemplate/core.lua
@@ -280,7 +280,9 @@ function rButtonTemplate:StyleItemButton(button,cfg)
   local normalTexture = button:GetNormalTexture()
   local pushedTexture = button:GetPushedTexture()
   local highlightTexture = button:GetHighlightTexture()
-  local checkedTexture = button:GetCheckedTexture()
+  --the new ItemButton frame type introduced in 8.1.5 does not have a checked texture
+  local checkedTexture = nil
+  if button.GetCheckedTexture then checkedTexture = button:GetCheckedTexture() end
 
   --backdrop
   SetupBackdrop(button,cfg.backdrop)


### PR DESCRIPTION
Just copied your code from the actionbutton styling section of the same file. The new ItemButton frame type in 8.1.5 doesn't use a checked texture it seems, so without that extra check the code bugs out. 

Feel free to use the fix, discard it in burning rage, implement your own probably better and more elegant, or whatever. I just woke up, saw in my inbox folder that somebody had posted an issue at your repo, and thought "why not"! :D 